### PR TITLE
Typo and command fix

### DIFF
--- a/codelab1/README.md
+++ b/codelab1/README.md
@@ -126,6 +126,7 @@ Even the curstom image includes all software, there are still a few steps to mak
 - This will take about 3 min. to make you the new owner of /ws/*.
 - [asd.sh](../asd.sh) includes setupVm function to do these steps for you. You can run it in a Terminal & close it. All new Terminal will be ready for development.
     ```
+      sed -i -e 's/\r$//' /ws/asd-codelabs/asd.sh
       /ws/asd-codelabs/asd.sh setupVm
     ```
 
@@ -162,7 +163,7 @@ Even the curstom image includes all software, there are still a few steps to mak
     3. Reset the VM & reconnect
     4. Launch Android Studio & [set it up](https://developer.android.com/studio/install#linux)
           ```
-          cd /ws/Android\ Studio/android-studio/bin
+          cd /ws/android-studio/bin
           ./studio.sh
           ```
     5. Start [AVD Manager](https://developer.android.com/studio/run/managing-avds)

--- a/codelab1/README.md
+++ b/codelab1/README.md
@@ -3,8 +3,8 @@ In this code lab, you will learn how to create a virtual machine on
 Google Cloud Platform(GCP) and access it by Chrome Remote Desktop(CRD) for
 Android system development.
 
-## Android developement on the cloud
-![Android Developement on the cloud](res/Android%20System%20Development%20On%20The%20Cloud.png)
+## Android development on the cloud
+![Android Development on the cloud](res/Android%20System%20Development%20On%20The%20Cloud.png)
 
 ## Create a new GCP project
 In this example, we will create a new project: **ASD Codelab1**.
@@ -12,14 +12,14 @@ Alternatively, You can use an existing project if it fits better.
 
 1. Follow the instructions for [Creating a project](https://cloud.google.com/resource-manager/docs/creating-managing-projects#creating_a_project)
     - Project name: **ASD Codelab1**
-    - Keep the Project ID handly as it's the unique identifier for your projec.
-    **my-project-id** is used as the example. Which should be replaced with the
+    - Keep the Project ID handly as it's the unique identifier for your project.
+    **my-project-id** is used as an example. Which should be replaced with the
     actual Project ID.
 
 <img src="res/startProj.png" width="400">
 
 2. If you never enable billing, [Enable billing](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
-first. So, you can proceed the following steps.
+first. So, you can proceed with the following steps.
 
 3. Enable Compute Engine API
     - In [GCP Console](http://console.cloud.google.com/), select the project: **ASD Codelab1**
@@ -41,16 +41,16 @@ first. So, you can proceed the following steps.
 export PROJECT_ID="asd-codelab1"
 gcloud projects list | grep ${PROJECT_ID}
 
-echo "Set the defult project for the section"
+echo "Set the default project for the section"
 gcloud config set project ${PROJECT_ID}
 ```
 
 ## Create a VM
 Now, let's create a VM with a custom image for development. By using a custom
-image you can skip many set up setps. In this example, we use a custom image
+image you can skip many setup steps. In this example, we use a custom image
 with all the software required for Android system development:
   - Linux: ubuntu 18.04
-  - Python 2.7 as repo depend on it.
+  - Python 2.7 as repo depends on it.
   - Set up for [Downloading Android Source](https://source.android.com/setup/build/downloading)
     - repo in /ws/bin
     - android11-qpr2-release source code in /ws/android
@@ -86,7 +86,7 @@ gcloud compute instances list
 <img src="res/VerifyVMCreation.png" width="800">
 
 ## Connect to the VM
-There are 2 ways to connect to the the VM on the cloud to use it: 1) SSH and 2)
+There are 2 ways to connect to the VM on the cloud to use it: 1) SSH and 2)
 Chrome Remote Desktop.
 
 1. SSH
@@ -96,15 +96,13 @@ Chrome Remote Desktop.
 <img src="res/SSH.png" width="800">
 
 2. Chrome Remote Desktop
-    - Chrome Remote Desktop provides GUI, which is easier to use. However, it
-    requires more bandwith than SSH & additional set up.
+    - Chrome Remote Desktop provides GUI, which is easier to use. However, it requires more bandwidth than SSH & additional setup.
     - Set it up by [Configuring and starting the Chrome Remote Desktop service](https://cloud.google.com/architecture/chrome-desktop-remote-on-compute-engine#configuring_and_starting_the_chrome_remote_desktop_service)
     - To copy & paste between your local machine & the VM, [Enable Clipboard Synchronization](https://cloud.google.com/architecture/chrome-desktop-remote-on-compute-engine#enable_clipboard_synchronization).
-    - For Windows users: the Windows app for chrome remote desktop is no longer
-    supported, use the web app instead.
+    - For Windows users: the Windows app for chrome remote desktop is no longer supported, use the web app instead.
 
 ## One-time setup of a new VM
-Even the curstom image includes all software, there are still a few steps to make a new VM ready for a user.
+Even the custom image includes all software, there are still a few steps to make a new VM ready for a user.
 ```
   echo "Check if kvm is enabled for the VM. If not, follow Enabling nested virtualization for VM instances"
   ls -l /dev/kvm
@@ -179,7 +177,7 @@ to reduce [the change](https://cloud.google.com/compute/docs/instances/instance-
 
 - Get to know [VM instance life cycle](https://cloud.google.com/compute/docs/instances/instance-life-cycle).
 - To manage it, go to [VM instances](https://console.cloud.google.com/compute/instances),
-to click STOP, START & etc. as fit, e.g.
+to click STOP, START &, etc. as fit, e.g.
 
 <img src="res/Stop_resume.png" width="800">
 

--- a/codelab2/README.md
+++ b/codelab2/README.md
@@ -1,5 +1,5 @@
 # Build An Android Virtual Device On The Cloud
-In this clode lab, you will learn how to build an Android Virtual Device(AVD),
+In this code lab, you will learn how to build an Android Virtual Device(AVD),
 sdk_phone_x86_64 on the cloud.
 
 ## Android build process in a nutshell
@@ -16,7 +16,7 @@ development universe.
 
 
 ### Download Android source code
-1. Pick an branch from [AOSP branch list](https://android.googlesource.com/platform/manifest/+refs).
+1. Pick a branch from [AOSP branch list](https://android.googlesource.com/platform/manifest/+refs).
 2. Read [Downloading the Source](https://source.android.com/setup/build/downloading)
 to learn more.
 3. A typical download flow for **android11-qpr2-release**.
@@ -31,8 +31,7 @@ to learn more.
 4. For a quickstart, use **/ws/android** in the codelab1 VM, **asd-vm1**.
     - **/ws/android** has android11-qpr2-release downloaded in the custom
     image.
-    - You don't need to do this, but just for fun, you may re-sync it. It'll
-    only take about 4 min. to re-sync.
+    - You don't need to do this, but just for fun, you may re-sync it. It'll only take about 4 min. to re-sync.
     ```
     cd /ws/android
     repo sync -j16
@@ -44,8 +43,7 @@ know more details.
 
 2. A quickstart to build sdk_phon_x86_64 AVD.
     - It may take more than 2 hours to build it from the scratch.
-    - To save time, you can use a prebuilt in **/ws/android**. Which only takes
-    few min. to rebuild.
+    - To save time, you can use a prebuilt in **/ws/android**. Which only takes a few min. to rebuild.
     - Note: the 1st **lunch** can take a few min. for each new VM.
 ```
 echo "Set android folder"
@@ -66,8 +64,8 @@ emulator &
 ```
 <img src="res/avd.png" width="400">
 
-## Poke aound
-Android Emulator provides many useful controls for you to play around an AVD,
+## Poke around
+Android Emulator provides many useful controls for you to play around with an AVD,
 such as:
 - [Perform common actions in the emulator](https://developer.android.com/studio/run/emulator#tasks)
 - Explore [Extened Control](https://developer.android.com/studio/run/emulator#extended)

--- a/codelab3/README.md
+++ b/codelab3/README.md
@@ -39,7 +39,7 @@ emulator &
 ```
 
 - Building **aphone** first time can take more than 7 min., but it's better
-than hours becanse it's pretty close to **sdk_phone_x86_64** to reuse many
+than hours because it's pretty close to **sdk_phone_x86_64** to reuse many
 same object files.
 
 6. Check the build fingerprint & Settings -> About emulated device for aphone,
@@ -110,7 +110,7 @@ include $(BUILD_PREBUILT)
 ```
 # ASD aphone apps
 PRODUCT_PACKAGES += \
-		jetsnack
+    jetsnack
 ```
 5. Build & run to check out Jetsnack app is preloaded.
 <img src="res/jetsnack.gif" width="300">

--- a/codelab4/README.md
+++ b/codelab4/README.md
@@ -93,7 +93,9 @@ gcloud compute instances create <YOUR_VM_NAME> \
    repo init -u https://android.googlesource.com/platform/manifest -b <SOURCE_TAG>
    repo sync -c -j<THREAD_COUNT>
    ```
-4. Building Android
+4. Install Android studio
+  - Follow the instructions to install Android studio on [Linux](https://developer.android.com/studio/install#linux)
+5. Building Android
    - Run setup script
    ```
    source build/envsetup.sh


### PR DESCRIPTION
## Codelab 1:
1. Fix typo
2. Remove old name in commands, e.g. cd /ws/Android \ studio -> cd /ws/android-studio
3. Add in ``` sed -i -e 's/\r$//' asd.sh``` to prevent error when executing asd.sh
## Codelab 2&3:
1. Fix typo
## Codelab 4:
1. Typo
2. Add in install Android studio
### Todo: 
1. Enable nested virtualization with command.
2. cleanup KVM list